### PR TITLE
#16: Refresh token: Get client based on subject

### DIFF
--- a/src/main/java/dev/jarand/authapi/oauth/domain/RefreshTokenParameters.java
+++ b/src/main/java/dev/jarand/authapi/oauth/domain/RefreshTokenParameters.java
@@ -1,5 +1,7 @@
 package dev.jarand.authapi.oauth.domain;
 
+import java.util.Optional;
+
 public class RefreshTokenParameters {
 
     private final String clientId;
@@ -12,12 +14,12 @@ public class RefreshTokenParameters {
         this.refreshToken = refreshToken;
     }
 
-    public String getClientId() {
-        return clientId;
+    public Optional<String> getClientId() {
+        return Optional.ofNullable(clientId);
     }
 
-    public String getClientSecret() {
-        return clientSecret;
+    public Optional<String> getClientSecret() {
+        return Optional.ofNullable(clientSecret);
     }
 
     public String getRefreshToken() {

--- a/src/main/java/dev/jarand/authapi/oauth/validator/RequestParametersValidator.java
+++ b/src/main/java/dev/jarand/authapi/oauth/validator/RequestParametersValidator.java
@@ -35,11 +35,11 @@ public class RequestParametersValidator {
                 final var clientId = requestParams.get("client_id");
                 final var clientSecret = requestParams.get("client_secret");
                 final var refreshToken = requestParams.get("refresh_token");
-                if (clientId == null || clientSecret == null || refreshToken == null) {
+                if (refreshToken == null) {
                     return RequestParameters.refreshToken(
                             INVALID,
                             null,
-                            new OAuthError("invalid_request", "Missing 'client_id' or 'client_secret' or 'refresh_token' parameter required for the 'refresh_token' grant type"));
+                            new OAuthError("invalid_request", "Missing 'refresh_token' parameter required for the 'refresh_token' grant type"));
                 }
                 return RequestParameters.refreshToken(VALID, new RefreshTokenParameters(clientId, clientSecret, refreshToken), null);
             }

--- a/src/test/java/dev/jarand/authapi/oauth/rest/OAuthIntegrationTest.java
+++ b/src/test/java/dev/jarand/authapi/oauth/rest/OAuthIntegrationTest.java
@@ -159,34 +159,6 @@ class OAuthIntegrationTest extends ApiTest {
     }
 
     @Test
-    void POST_token_for_refresh_token_flow_without_client_id_should_return_error() throws Exception {
-        final var mvcResult = mockMvc.perform(
-                post("/oauth/token")
-                        .param("grant_type", "refresh_token")
-                        .param("client_secret", "wrongSecret")
-                        .param("refresh_token", "someRefreshToken"))
-                .andExpect(status().isBadRequest()).andReturn();
-
-        final var actualJson = mvcResult.getResponse().getContentAsString();
-        final var expectedJson = fileAsString("/token/refresh-token/missing-client-id.json");
-        JSONAssert.assertEquals(expectedJson, actualJson, true);
-    }
-
-    @Test
-    void POST_token_for_refresh_token_flow_without_client_secret_should_return_error() throws Exception {
-        final var mvcResult = mockMvc.perform(
-                post("/oauth/token")
-                        .param("grant_type", "refresh_token")
-                        .param("client_id", "wrongId")
-                        .param("refresh_token", "someRefreshToken"))
-                .andExpect(status().isBadRequest()).andReturn();
-
-        final var actualJson = mvcResult.getResponse().getContentAsString();
-        final var expectedJson = fileAsString("/token/refresh-token/missing-client-secret.json");
-        JSONAssert.assertEquals(expectedJson, actualJson, true);
-    }
-
-    @Test
     void POST_token_for_refresh_token_flow_without_refresh_token_secret_should_return_error() throws Exception {
         final var mvcResult = mockMvc.perform(
                 post("/oauth/token")

--- a/src/test/resources/token/refresh-token/missing-client-id.json
+++ b/src/test/resources/token/refresh-token/missing-client-id.json
@@ -1,4 +1,0 @@
-{
-  "error": "invalid_request",
-  "error_description": "Missing 'client_id' or 'client_secret' or 'refresh_token' parameter required for the 'refresh_token' grant type"
-}

--- a/src/test/resources/token/refresh-token/missing-client-secret.json
+++ b/src/test/resources/token/refresh-token/missing-client-secret.json
@@ -1,4 +1,0 @@
-{
-  "error": "invalid_request",
-  "error_description": "Missing 'client_id' or 'client_secret' or 'refresh_token' parameter required for the 'refresh_token' grant type"
-}

--- a/src/test/resources/token/refresh-token/missing-parameters.json
+++ b/src/test/resources/token/refresh-token/missing-parameters.json
@@ -1,4 +1,4 @@
 {
   "error": "invalid_request",
-  "error_description": "Missing 'client_id' or 'client_secret' or 'refresh_token' parameter required for the 'refresh_token' grant type"
+  "error_description": "Missing 'refresh_token' parameter required for the 'refresh_token' grant type"
 }

--- a/src/test/resources/token/refresh-token/missing-refresh-token.json
+++ b/src/test/resources/token/refresh-token/missing-refresh-token.json
@@ -1,4 +1,4 @@
 {
   "error": "invalid_request",
-  "error_description": "Missing 'client_id' or 'client_secret' or 'refresh_token' parameter required for the 'refresh_token' grant type"
+  "error_description": "Missing 'refresh_token' parameter required for the 'refresh_token' grant type"
 }


### PR DESCRIPTION
This makes it possible for client credentials to be optional, which is needed for the password client to use the refresh token flow correctly. If the client has client credentials (secret client), we will still authenticate the client.